### PR TITLE
Add glob command line parameter

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -6,6 +6,7 @@ program
 .version('0.0.0')
 .usage('[options]')
 .option('-v, --verbose', 'Enable verbose logging')
+.option('-g, --glob <glob>', 'Set the glob')
 .parse(process.argv)
 
 const { verbose } = program

--- a/bin/install.js
+++ b/bin/install.js
@@ -9,7 +9,7 @@ program
 .option('-g, --glob <glob>', 'Set the glob')
 .parse(process.argv)
 
-const { verbose } = program
-const options = { verbose }
+const { glob, verbose } = program
+const options = { glob, verbose }
 
 require('../src/execute')('yarpm install', options)


### PR DESCRIPTION
Allows to add the glob as a command line parameter, e.g. to restrict the path to look for package.jsons